### PR TITLE
Handle missing hourly market cap and volume in price history

### DIFF
--- a/bear_bull/src/main/java/si/iitech/bear_bull_service/PriceService.java
+++ b/bear_bull/src/main/java/si/iitech/bear_bull_service/PriceService.java
@@ -84,13 +84,20 @@ public class PriceService {
 			Double totalVolumeValue = totalVolumeValues != null ? totalVolumeValues.get(0).getValue1() : 0.0;
 			createPrice(coin, priceDate, priceValue, marketCapValue, totalVolumeValue,
 					PriceType.DAILY, currentPrices);
-			if (prices.size() > 1) {
-				for (int i = 0; i < prices.size(); i++) {
-					createPrice(coin, prices.get(i).getValue0(), prices.get(i).getValue1(),
-							marketCapValues.get(i).getValue1(), totalVolumeValues.get(i).getValue1(), PriceType.HOURLY,
-							currentPrices);
-				}
-			}
+                        if (prices.size() > 1) {
+                                for (int i = 0; i < prices.size(); i++) {
+                                        double hourlyMarketCapValue = 0.0;
+                                        if (marketCapValues != null && marketCapValues.size() > i && marketCapValues.get(i) != null) {
+                                                hourlyMarketCapValue = marketCapValues.get(i).getValue1();
+                                        }
+                                        double hourlyTotalVolumeValue = 0.0;
+                                        if (totalVolumeValues != null && totalVolumeValues.size() > i && totalVolumeValues.get(i) != null) {
+                                                hourlyTotalVolumeValue = totalVolumeValues.get(i).getValue1();
+                                        }
+                                        createPrice(coin, prices.get(i).getValue0(), prices.get(i).getValue1(),
+                                                        hourlyMarketCapValue, hourlyTotalVolumeValue, PriceType.HOURLY, currentPrices);
+                                }
+                        }
 		}
 		EtPrice.getEntityManager().flush();
 		List<EtPrice> allCurrentDailyPrices = EtPrice.getPrices(coin.id, DateUtils.addDays(from, -45), until,


### PR DESCRIPTION
## Summary
- Avoid NullPointerException when hourly market cap or total volume data is missing in CoinGecko responses

## Testing
- `mvn -q -pl bear_bull test` *(fails: Non-resolvable import POM: Could not transfer artifact io.quarkus.platform:quarkus-bom:pom:3.3.3)*

------
https://chatgpt.com/codex/tasks/task_e_68990e80521c8331bd393c1c91f24c2a